### PR TITLE
WSS example fixes

### DIFF
--- a/docs/wss/eth_subscribe.md
+++ b/docs/wss/eth_subscribe.md
@@ -16,16 +16,16 @@ Creates a new subscription over particular events. The node will return a subscr
 >wscat -c wss://mainnet.infura.io/ws 
 
 // newHeads
->{"id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
+>{"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["newHeads"]}
 
 // logs
->{"id": 1, "method": "eth_subscribe", "params": ["logs", {"address": "0x8320fe7702b96808f7bbc0d4a888ed1468216cfd", "topics": ["0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"]}]}
+>{"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["logs", {"address": "0x8320fe7702b96808f7bbc0d4a888ed1468216cfd", "topics": ["0xd78a0cb8bb633d06981248b816e7bd33c2a35a6089241d099fa519e361cab902"]}]}
 
 // newPendingTransactions
->{"id": 1, "method": "eth_subscribe", "params": ["newPendingTransactions"]}
+>{"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["newPendingTransactions"]}
 
 // syncing (not supported on Kovan)
->{"id": 1, "method": "eth_subscribe", "params": ["syncing"]}
+>{"jsonrpc":"2.0", "id": 1, "method": "eth_subscribe", "params": ["syncing"]}
 ```
 
 ### RESPONSE
@@ -96,6 +96,7 @@ Creates a new subscription over particular events. The node will return a subscr
 
 // syncing subscription (not supported on Kovan)
 {
+    "jsonrpc":"2.0",
     "subscription":"0xe2ffeb2703bcf602d42922385829ce96",
     "result": { 
         "syncing":true,

--- a/docs/wss/eth_unsubscribe.md
+++ b/docs/wss/eth_unsubscribe.md
@@ -9,7 +9,7 @@ Subscriptions are cancelled with a regular RPC call with eth_unsubscribe as meth
 ```bash
 >wscat -c wss://mainnet.infura.io/ws 
 
->{"id": 1, "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}
+>{"jsonrpc":"2.0", "id": 1, "method": "eth_unsubscribe", "params": ["0x9cef478923ff08bf67fde6c64013158d"]}
 ```
 
 ### RESPONSE

--- a/docs/wss/parity_subscribe.md
+++ b/docs/wss/parity_subscribe.md
@@ -14,7 +14,7 @@ NOTE: parity_subscribe is only supported on the Kovan network
 >wscat -c wss://kovan.infura.io/ws
 
 // subscribe to eth_getBalance
->{"method":"parity_subscribe","params":["eth_getBalance",["0x004702bdcC3C7dbFfd943136107E70B827028600","latest"]],"id":1,"jsonrpc":"2.0"}
+>{"jsonrpc":"2.0", "id":1, "method":"parity_subscribe", "params":["eth_getBalance",["0x004702bdcC3C7dbFfd943136107E70B827028600", "latest"]]}
 ```
 
 ### RESPONSE

--- a/docs/wss/parity_unsubscribe.md
+++ b/docs/wss/parity_unsubscribe.md
@@ -10,7 +10,7 @@ NOTE: parity_unsubscribe is only supported on the Kovan network
 ```bash
 >wscat -c wss://kovan.infura.io/ws
 
->{"method":"parity_unsubscribe","params":["0x070fa1c4d1b3fd81"],"id":1,"jsonrpc":"2.0"}
+>{"jsonrpc":"2.0", "id":1, "method":"parity_unsubscribe", "params":["0x070fa1c4d1b3fd81"]}
 ```
 
 ### RESPONSE


### PR DESCRIPTION
Added "jsonrpc: 2.0" where missing in the examples, while testing with Parity websockets its absence was causing issues.