### PR TITLE
clarify websockets API support

### DIFF
--- a/docs/ethereum/wss/introduction.md
+++ b/docs/ethereum/wss/introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
 Infura's websocket endpoint provides support for Pub/Sub API as well as JSON-RPC filter support.
-The regular Ethereum API is also supported and documented in the 'examples' portion of 'Ethereum API'
+Additionally, the regular Ethereum JSON-RPC API is also supported over a websocket connection and documented in the 'EXAMPLE' portion for each 'Ethereum JSON-RPC' call.
 
 All examples in this reference section uses `wscat`, but will work with any tool that supports websockets.
 


### PR DESCRIPTION
There was recently some confusion around websockets support, based on documentation and past support. When reading through the docs, the two quoted parts were unclear to me:
- there is no section called "ETHEREUM API", I assume that is "ETHEREUM JSON-RPC"
- there is no section called "examples", but each API doc has an "EXAMPLE" section

Not trying to be pedantic, just trying to make sure my understanding is correct. If you decide to merge, hopefully better for the next people to read the docs.